### PR TITLE
Add Rust JSON interop client and smoke runner

### DIFF
--- a/interop/README.md
+++ b/interop/README.md
@@ -1,0 +1,72 @@
+# kkrpc Cross-Language Interop (Draft)
+
+This folder provides a **minimal JSON-only** interoperability layer so non-JS runtimes can
+speak to a TypeScript kkrpc endpoint over line-delimited JSON.
+
+## Protocol Snapshot
+
+- **Transport**: newline-delimited UTF-8 JSON strings.
+- **Serialization**:
+  - `version: "json"` indicates plain JSON.
+  - SuperJSON messages start with `{ "json": ... }` and are parsed by JS/TS; other runtimes
+    can choose to ignore or only implement `version: "json"`.
+- **Message shape**:
+
+```json
+{
+  "id": "<random-id>",
+  "method": "math.add",
+  "args": [1, 2],
+  "type": "request",
+  "version": "json",
+  "callbackIds": ["<optional-callback-id>"]
+}
+```
+
+### Message Types
+
+| type        | Required fields                     | Notes |
+| ----------- | ----------------------------------- | ----- |
+| `request`   | `id`, `method`, `args`              | Remote function call.
+| `response`  | `id`, `args.result` or `args.error` | Returned by server or client.
+| `callback`  | `method` (callback id), `args`      | Invokes a previously sent callback.
+| `get`       | `id`, `path`                        | Property read.
+| `set`       | `id`, `path`, `value`               | Property write.
+| `construct` | `id`, `method`, `args`              | Remote constructor call.
+
+### Callback Encoding
+
+If an argument is a callable, it is replaced by a string marker:
+
+```
+"__callback__<callback-id>"
+```
+
+The receiver stores a callback map keyed by `<callback-id>` and sends a `callback`
+message when invoked.
+
+## Implementations
+
+### Python
+
+- `interop/python/kkrpc.py` contains a small client + server implementation.
+- `interop/python/smoke_test.py` starts a Bun/Node kkrpc server and exercises calls + callbacks.
+
+### Go
+
+- `interop/go/kkrpc.go` contains a small client implementation.
+- `interop/go/smoke.go` starts a Bun/Node kkrpc server and exercises calls + callbacks.
+
+### Rust
+
+- `interop/rust/` contains a Cargo project with a JSON-mode client and smoke runner.
+
+### Node Test Server
+
+- `interop/node/server.ts` exposes `math.add`, `echo`, and `withCallback` using JSON mode.
+
+## Design Notes
+
+- This draft intentionally **omits transfer slots** and structured clone support.
+- Cross-language targets should start with `version: "json"` and add SuperJSON support later
+  if needed.

--- a/interop/go/kkrpc.go
+++ b/interop/go/kkrpc.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+const callbackPrefix = "__callback__"
+
+type Callback func(args ...any)
+
+type rpcError struct {
+	Name    string
+	Message string
+	Data    any
+}
+
+func (e *rpcError) Error() string {
+	if e.Name == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Name, e.Message)
+}
+
+type responsePayload struct {
+	Result any
+	Err    error
+}
+
+type Client struct {
+	reader    *bufio.Reader
+	writer    *bufio.Writer
+	pending   map[string]chan responsePayload
+	callbacks map[string]Callback
+	mu        sync.Mutex
+}
+
+func NewClient(reader *bufio.Reader, writer *bufio.Writer) *Client {
+	client := &Client{
+		reader:    reader,
+		writer:    writer,
+		pending:   make(map[string]chan responsePayload),
+		callbacks: make(map[string]Callback),
+	}
+	go client.readLoop()
+	return client
+}
+
+func (c *Client) Call(method string, args ...any) (any, error) {
+	requestID := generateUUID()
+	responseCh := make(chan responsePayload, 1)
+	c.mu.Lock()
+	c.pending[requestID] = responseCh
+	c.mu.Unlock()
+
+	processedArgs := make([]any, 0, len(args))
+	callbackIDs := make([]string, 0)
+	for _, arg := range args {
+		if cb, ok := arg.(Callback); ok {
+			callbackID := generateUUID()
+			c.mu.Lock()
+			c.callbacks[callbackID] = cb
+			c.mu.Unlock()
+			callbackIDs = append(callbackIDs, callbackID)
+			processedArgs = append(processedArgs, callbackPrefix+callbackID)
+			continue
+		}
+		processedArgs = append(processedArgs, arg)
+	}
+
+	payload := map[string]any{
+		"id":      requestID,
+		"method":  method,
+		"args":    processedArgs,
+		"type":    "request",
+		"version": "json",
+	}
+	if len(callbackIDs) > 0 {
+		payload["callbackIds"] = callbackIDs
+	}
+
+	if err := c.writeMessage(payload); err != nil {
+		return nil, err
+	}
+
+	response := <-responseCh
+	return response.Result, response.Err
+}
+
+func (c *Client) writeMessage(payload map[string]any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, err := c.writer.WriteString(string(data) + "\n"); err != nil {
+		return err
+	}
+	return c.writer.Flush()
+}
+
+func (c *Client) readLoop() {
+	for {
+		line, err := c.reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var message map[string]any
+		if err := json.Unmarshal([]byte(line), &message); err != nil {
+			continue
+		}
+		messageType, _ := message["type"].(string)
+		switch messageType {
+		case "response":
+			c.handleResponse(message)
+		case "callback":
+			c.handleCallback(message)
+		}
+	}
+}
+
+func (c *Client) handleResponse(message map[string]any) {
+	requestID, _ := message["id"].(string)
+	c.mu.Lock()
+	responseCh, ok := c.pending[requestID]
+	if ok {
+		delete(c.pending, requestID)
+	}
+	c.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	args, _ := message["args"].(map[string]any)
+	if args == nil {
+		responseCh <- responsePayload{Result: nil}
+		return
+	}
+	if errValue, exists := args["error"]; exists {
+		responseCh <- responsePayload{Result: nil, Err: decodeError(errValue)}
+		return
+	}
+	responseCh <- responsePayload{Result: args["result"], Err: nil}
+}
+
+func (c *Client) handleCallback(message map[string]any) {
+	callbackID, _ := message["method"].(string)
+	c.mu.Lock()
+	callback := c.callbacks[callbackID]
+	c.mu.Unlock()
+	if callback == nil {
+		return
+	}
+
+	argsRaw, _ := message["args"].([]any)
+	if argsRaw == nil {
+		callback()
+		return
+	}
+	callback(argsRaw...)
+}
+
+func decodeError(value any) error {
+	if value == nil {
+		return errors.New("unknown error")
+	}
+	if errMap, ok := value.(map[string]any); ok {
+		name, _ := errMap["name"].(string)
+		message, _ := errMap["message"].(string)
+		return &rpcError{Name: name, Message: message, Data: errMap}
+	}
+	return fmt.Errorf("%v", value)
+}
+
+func generateUUID() string {
+	parts := make([]string, 0, 4)
+	for i := 0; i < 4; i++ {
+		parts = append(parts, fmt.Sprintf("%x", rand.Int63()))
+	}
+	return strings.Join(parts, "-")
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func newStdioClient() *Client {
+	return NewClient(bufio.NewReader(os.Stdin), bufio.NewWriter(os.Stdout))
+}

--- a/interop/go/smoke.go
+++ b/interop/go/smoke.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+func main() {
+	root, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	serverPath := filepath.Join(root, "interop", "node", "server.ts")
+
+	cmd := exec.Command("bun", serverPath)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		panic(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		panic(err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		panic(err)
+	}
+
+	client := NewClient(bufio.NewReader(stdout), bufio.NewWriter(stdin))
+
+	result, err := client.Call("math.add", 4, 7)
+	if err != nil {
+		panic(err)
+	}
+	if number, ok := result.(float64); !ok || number != 11 {
+		panic(fmt.Sprintf("unexpected add result: %#v", result))
+	}
+
+	echoInput := map[string]any{"name": "kkrpc", "count": 2}
+	echoResult, err := client.Call("echo", echoInput)
+	if err != nil {
+		panic(err)
+	}
+	if !compareMaps(echoInput, echoResult) {
+		panic(fmt.Sprintf("unexpected echo result: %#v", echoResult))
+	}
+
+	callbackCh := make(chan string, 1)
+	callback := Callback(func(args ...any) {
+		if len(args) > 0 {
+			callbackCh <- fmt.Sprintf("%v", args[0])
+		}
+	})
+
+	callbackResult, err := client.Call("withCallback", "pong", callback)
+	if err != nil {
+		panic(err)
+	}
+	if callbackResult != "callback-sent" {
+		panic(fmt.Sprintf("unexpected callback result: %#v", callbackResult))
+	}
+
+	select {
+	case value := <-callbackCh:
+		if value != "callback:pong" {
+			panic(fmt.Sprintf("unexpected callback payload: %s", value))
+		}
+	case <-time.After(2 * time.Second):
+		panic(errors.New("callback not received"))
+	}
+
+	_ = stdin.Close()
+	_ = stdout.Close()
+	_ = stderr.Close()
+
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+}
+
+func compareMaps(expected map[string]any, actual any) bool {
+	actualMap, ok := actual.(map[string]any)
+	if !ok {
+		return false
+	}
+	for key, value := range expected {
+		actualValue, exists := actualMap[key]
+		if !exists || !valuesEqual(value, actualValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func valuesEqual(expected any, actual any) bool {
+	if expectedNumber, ok := toFloat64(expected); ok {
+		if actualNumber, ok := toFloat64(actual); ok {
+			return expectedNumber == actualNumber
+		}
+	}
+	return expected == actual
+}
+
+func toFloat64(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case float32:
+		return float64(typed), true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case uint:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case uint32:
+		return float64(typed), true
+	default:
+		return 0, false
+	}
+}

--- a/interop/go/smoke.go
+++ b/interop/go/smoke.go
@@ -44,6 +44,7 @@ func main() {
 	if number, ok := result.(float64); !ok || number != 11 {
 		panic(fmt.Sprintf("unexpected add result: %#v", result))
 	}
+	fmt.Printf("[go] math.add(4, 7) => %v\n", result)
 
 	echoInput := map[string]any{"name": "kkrpc", "count": 2}
 	echoResult, err := client.Call("echo", echoInput)
@@ -53,6 +54,7 @@ func main() {
 	if !compareMaps(echoInput, echoResult) {
 		panic(fmt.Sprintf("unexpected echo result: %#v", echoResult))
 	}
+	fmt.Printf("[go] echo(%v) => %v\n", echoInput, echoResult)
 
 	callbackCh := make(chan string, 1)
 	callback := Callback(func(args ...any) {
@@ -68,12 +70,14 @@ func main() {
 	if callbackResult != "callback-sent" {
 		panic(fmt.Sprintf("unexpected callback result: %#v", callbackResult))
 	}
+	fmt.Printf("[go] withCallback(\"pong\", cb) => %v\n", callbackResult)
 
 	select {
 	case value := <-callbackCh:
 		if value != "callback:pong" {
 			panic(fmt.Sprintf("unexpected callback payload: %s", value))
 		}
+		fmt.Printf("[go] callback received => %s\n", value)
 	case <-time.After(2 * time.Second):
 		panic(errors.New("callback not received"))
 	}

--- a/interop/node/server.ts
+++ b/interop/node/server.ts
@@ -1,0 +1,22 @@
+import { NodeIo, RPCChannel } from "../../packages/kkrpc/mod.ts"
+
+const io = new NodeIo(process.stdin, process.stdout)
+const api = {
+	math: {
+		add(a: number, b: number) {
+			return a + b
+		}
+	},
+	echo<T>(value: T) {
+		return value
+	},
+	withCallback(value: string, cb: (payload: string) => void) {
+		cb(`callback:${value}`)
+		return "callback-sent"
+	}
+}
+
+new RPCChannel(io, {
+	expose: api,
+	serialization: { version: "json" }
+})

--- a/interop/python/kkrpc.py
+++ b/interop/python/kkrpc.py
@@ -1,0 +1,310 @@
+import json
+import queue
+import random
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, TextIO
+
+
+CALLBACK_PREFIX = "__callback__"
+
+
+def generate_uuid() -> str:
+	return "-".join(f"{random.getrandbits(53):x}" for _ in range(4))
+
+
+class RpcError(RuntimeError):
+	def __init__(self, message: str, name: Optional[str] = None, data: Any = None) -> None:
+		super().__init__(message)
+		self.name = name
+		self.data = data
+
+
+@dataclass
+class PendingRequest:
+	queue: "queue.Queue[Any]"
+
+
+class RpcClient:
+	def __init__(self, reader: TextIO, writer: TextIO) -> None:
+		self._reader = reader
+		self._writer = writer
+		self._pending: Dict[str, PendingRequest] = {}
+		self._callbacks: Dict[str, Callable[..., Any]] = {}
+		self._lock = threading.Lock()
+		self._buffer = ""
+		self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
+		self._reader_thread.start()
+
+	def call(self, method: str, *args: Any) -> Any:
+		return self._send_request("request", method=method, args=list(args))
+
+	def get(self, path: Iterable[str]) -> Any:
+		return self._send_request("get", path=list(path))
+
+	def set(self, path: Iterable[str], value: Any) -> Any:
+		return self._send_request("set", path=list(path), value=value)
+
+	def construct(self, method: str, *args: Any) -> Any:
+		return self._send_request("construct", method=method, args=list(args))
+
+	def close(self) -> None:
+		try:
+			self._writer.close()
+		except OSError:
+			pass
+
+	def _send_request(
+		self,
+		message_type: str,
+		method: str = "",
+		args: Optional[List[Any]] = None,
+		path: Optional[List[str]] = None,
+		value: Any = None
+	) -> Any:
+		request_id = generate_uuid()
+		pending = PendingRequest(queue=queue.Queue(maxsize=1))
+		self._pending[request_id] = pending
+		callback_ids: List[str] = []
+
+		processed_args: List[Any] = []
+		if args is not None:
+			for arg in args:
+				if callable(arg):
+					callback_id = generate_uuid()
+					self._callbacks[callback_id] = arg
+					callback_ids.append(callback_id)
+					processed_args.append(f"{CALLBACK_PREFIX}{callback_id}")
+				else:
+					processed_args.append(arg)
+
+		payload: Dict[str, Any] = {
+			"id": request_id,
+			"method": method,
+			"args": processed_args,
+			"type": message_type,
+			"version": "json"
+		}
+
+		if callback_ids:
+			payload["callbackIds"] = callback_ids
+		if path is not None:
+			payload["path"] = path
+		if value is not None:
+			payload["value"] = value
+
+		self._write_message(payload)
+		response = pending.queue.get()
+		if isinstance(response, Exception):
+			raise response
+		return response
+
+	def _write_message(self, payload: Dict[str, Any]) -> None:
+		line = json.dumps(payload, ensure_ascii=False)
+		with self._lock:
+			self._writer.write(f"{line}\n")
+			self._writer.flush()
+
+	def _read_loop(self) -> None:
+		for line in self._reader:
+			line = line.strip()
+			if not line:
+				continue
+			try:
+				message = json.loads(line)
+			except json.JSONDecodeError:
+				continue
+			self._handle_message(message)
+
+	def _handle_message(self, message: Dict[str, Any]) -> None:
+		message_type = message.get("type")
+		if message_type == "response":
+			self._handle_response(message)
+		elif message_type == "callback":
+			self._handle_callback(message)
+
+	def _handle_response(self, message: Dict[str, Any]) -> None:
+		request_id = message.get("id")
+		pending = self._pending.pop(request_id, None)
+		if not pending:
+			return
+		args = message.get("args", {})
+		if isinstance(args, dict) and "error" in args:
+			error_value = args.get("error")
+			if isinstance(error_value, dict):
+				pending.queue.put(
+					RpcError(
+						error_value.get("message", "RPC error"),
+						name=error_value.get("name"),
+						data=error_value
+					)
+				)
+			else:
+				pending.queue.put(RpcError(str(error_value)))
+			return
+		pending.queue.put(args.get("result"))
+
+	def _handle_callback(self, message: Dict[str, Any]) -> None:
+		callback_id = message.get("method")
+		callback = self._callbacks.get(callback_id)
+		if not callback:
+			return
+		args = message.get("args")
+		if not isinstance(args, list):
+			args = []
+		callback(*args)
+
+
+class RpcServer:
+	def __init__(self, reader: TextIO, writer: TextIO, api: Dict[str, Any]) -> None:
+		self._reader = reader
+		self._writer = writer
+		self._api = api
+		self._lock = threading.Lock()
+		self._buffer = ""
+		self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
+		self._reader_thread.start()
+
+	def _write_message(self, payload: Dict[str, Any]) -> None:
+		line = json.dumps(payload, ensure_ascii=False)
+		with self._lock:
+			self._writer.write(f"{line}\n")
+			self._writer.flush()
+
+	def _read_loop(self) -> None:
+		for line in self._reader:
+			line = line.strip()
+			if not line:
+				continue
+			try:
+				message = json.loads(line)
+			except json.JSONDecodeError:
+				continue
+			self._handle_message(message)
+
+	def _handle_message(self, message: Dict[str, Any]) -> None:
+		message_type = message.get("type")
+		if message_type == "request":
+			self._handle_request(message)
+		elif message_type == "get":
+			self._handle_get(message)
+		elif message_type == "set":
+			self._handle_set(message)
+		elif message_type == "construct":
+			self._handle_construct(message)
+
+	def _resolve_path(self, path: List[str]) -> Any:
+		target: Any = self._api
+		for part in path:
+			if not isinstance(target, dict) or part not in target:
+				raise KeyError(".".join(path))
+			target = target[part]
+		return target
+
+	def _wrap_callbacks(self, args: List[Any], request_id: str) -> List[Any]:
+		processed: List[Any] = []
+		for arg in args:
+			if isinstance(arg, str) and arg.startswith(CALLBACK_PREFIX):
+				callback_id = arg[len(CALLBACK_PREFIX) :]
+
+				def _callback(*callback_args: Any) -> None:
+					self._write_message(
+						{
+							"id": request_id,
+							"method": callback_id,
+							"args": list(callback_args),
+							"type": "callback",
+							"version": "json"
+						}
+					)
+
+				processed.append(_callback)
+			else:
+				processed.append(arg)
+		return processed
+
+	def _send_response(self, request_id: str, result: Any) -> None:
+		self._write_message(
+			{
+				"id": request_id,
+				"method": "",
+				"args": {"result": result},
+				"type": "response",
+				"version": "json"
+			}
+		)
+
+	def _send_error(self, request_id: str, error: Exception) -> None:
+		self._write_message(
+			{
+				"id": request_id,
+				"method": "",
+				"args": {
+					"error": {
+						"name": error.__class__.__name__,
+						"message": str(error)
+					}
+				},
+				"type": "response",
+				"version": "json"
+			}
+		)
+
+	def _handle_request(self, message: Dict[str, Any]) -> None:
+		request_id = message.get("id", "")
+		method = message.get("method", "")
+		args = message.get("args")
+		if not isinstance(args, list):
+			args = []
+		try:
+			path = method.split(".") if method else []
+			target = self._resolve_path(path)
+			if not callable(target):
+				raise TypeError(f"Method {method} is not callable")
+			result = target(*self._wrap_callbacks(args, request_id))
+			self._send_response(request_id, result)
+		except Exception as error:
+			self._send_error(request_id, error)
+
+	def _handle_get(self, message: Dict[str, Any]) -> None:
+		request_id = message.get("id", "")
+		path = message.get("path")
+		if not isinstance(path, list):
+			self._send_error(request_id, ValueError("Missing path"))
+			return
+		try:
+			result = self._resolve_path(path)
+			self._send_response(request_id, result)
+		except Exception as error:
+			self._send_error(request_id, error)
+
+	def _handle_set(self, message: Dict[str, Any]) -> None:
+		request_id = message.get("id", "")
+		path = message.get("path")
+		if not isinstance(path, list) or not path:
+			self._send_error(request_id, ValueError("Missing path"))
+			return
+		try:
+			parent = self._resolve_path(path[:-1])
+			if not isinstance(parent, dict):
+				raise TypeError("Set target is not an object")
+			parent[path[-1]] = message.get("value")
+			self._send_response(request_id, True)
+		except Exception as error:
+			self._send_error(request_id, error)
+
+	def _handle_construct(self, message: Dict[str, Any]) -> None:
+		request_id = message.get("id", "")
+		method = message.get("method", "")
+		args = message.get("args")
+		if not isinstance(args, list):
+			args = []
+		try:
+			path = method.split(".") if method else []
+			constructor = self._resolve_path(path)
+			if not callable(constructor):
+				raise TypeError(f"Constructor {method} is not callable")
+			result = constructor(*self._wrap_callbacks(args, request_id))
+			self._send_response(request_id, result)
+		except Exception as error:
+			self._send_error(request_id, error)

--- a/interop/python/smoke_test.py
+++ b/interop/python/smoke_test.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import threading
+import time
+
+from kkrpc import RpcClient
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SERVER_PATH = os.path.join(ROOT, "interop", "node", "server.ts")
+
+
+def main() -> int:
+	process = subprocess.Popen(
+		["bun", SERVER_PATH],
+		stdin=subprocess.PIPE,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		text=True,
+		cwd=ROOT
+	)
+	assert process.stdin is not None
+	assert process.stdout is not None
+
+	client = RpcClient(process.stdout, process.stdin)
+
+	try:
+		result = client.call("math.add", 2, 3)
+		assert result == 5, f"unexpected add result {result}"
+
+		echo_value = {"name": "kkrpc", "count": 1}
+		echo_result = client.call("echo", echo_value)
+		assert echo_result == echo_value, f"unexpected echo result {echo_result}"
+
+		callback_event = threading.Event()
+		callback_payload = {}
+
+		def on_callback(value: str) -> None:
+			callback_payload["value"] = value
+			callback_event.set()
+
+		callback_result = client.call("withCallback", "ping", on_callback)
+		assert callback_result == "callback-sent"
+
+		if not callback_event.wait(timeout=2):
+			raise RuntimeError("callback not received")
+		assert callback_payload["value"] == "callback:ping"
+	finally:
+		client.close()
+		process.terminate()
+		try:
+			process.wait(timeout=5)
+		except subprocess.TimeoutExpired:
+			process.kill()
+
+	stderr = process.stderr.read() if process.stderr else ""
+	if stderr.strip():
+		print(stderr)
+
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/interop/python/smoke_test.py
+++ b/interop/python/smoke_test.py
@@ -27,10 +27,12 @@ def main() -> int:
 	try:
 		result = client.call("math.add", 2, 3)
 		assert result == 5, f"unexpected add result {result}"
+		print(f"[python] math.add(2, 3) => {result}")
 
 		echo_value = {"name": "kkrpc", "count": 1}
 		echo_result = client.call("echo", echo_value)
 		assert echo_result == echo_value, f"unexpected echo result {echo_result}"
+		print(f"[python] echo({echo_value}) => {echo_result}")
 
 		callback_event = threading.Event()
 		callback_payload = {}
@@ -41,10 +43,12 @@ def main() -> int:
 
 		callback_result = client.call("withCallback", "ping", on_callback)
 		assert callback_result == "callback-sent"
+		print(f"[python] withCallback('ping', cb) => {callback_result}")
 
 		if not callback_event.wait(timeout=2):
 			raise RuntimeError("callback not received")
 		assert callback_payload["value"] == "callback:ping"
+		print(f"[python] callback received => {callback_payload['value']}")
 	finally:
 		client.close()
 		process.terminate()

--- a/interop/rust/Cargo.toml
+++ b/interop/rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "kkrpc-interop"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/interop/rust/src/lib.rs
+++ b/interop/rust/src/lib.rs
@@ -1,0 +1,223 @@
+use rand::Rng;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+pub const CALLBACK_PREFIX: &str = "__callback__";
+
+type Callback = Arc<dyn Fn(Vec<Value>) + Send + Sync + 'static>;
+
+type ResponseSender = std::sync::mpsc::Sender<ResponsePayload>;
+
+type ResponseReceiver = std::sync::mpsc::Receiver<ResponsePayload>;
+
+#[derive(Debug)]
+pub struct RpcError {
+    pub name: Option<String>,
+    pub message: String,
+    pub data: Value,
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(name) = &self.name {
+            write!(f, "{}: {}", name, self.message)
+        } else {
+            write!(f, "{}", self.message)
+        }
+    }
+}
+
+impl std::error::Error for RpcError {}
+
+#[derive(Debug)]
+struct ResponsePayload {
+    result: Option<Value>,
+    error: Option<RpcError>,
+}
+
+pub enum Arg {
+    Value(Value),
+    Callback(Callback),
+}
+
+pub struct Client<W: Write + Send + 'static> {
+    writer: Arc<Mutex<W>>,
+    pending: Arc<Mutex<HashMap<String, ResponseSender>>>,
+    callbacks: Arc<Mutex<HashMap<String, Callback>>>,
+}
+
+impl<W: Write + Send + 'static> Client<W> {
+    pub fn new<R: std::io::Read + Send + 'static>(reader: R, writer: W) -> Self {
+        let pending: Arc<Mutex<HashMap<String, ResponseSender>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let callbacks: Arc<Mutex<HashMap<String, Callback>>> = Arc::new(Mutex::new(HashMap::new()));
+        let writer = Arc::new(Mutex::new(writer));
+
+        let pending_clone = Arc::clone(&pending);
+        let callbacks_clone = Arc::clone(&callbacks);
+        thread::spawn(move || {
+            let buffered = BufReader::new(reader);
+            for line in buffered.lines() {
+                let line = match line {
+                    Ok(line) => line,
+                    Err(_) => break,
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let message: Value = match serde_json::from_str(trimmed) {
+                    Ok(value) => value,
+                    Err(_) => continue,
+                };
+                let message_type = message.get("type").and_then(|v| v.as_str());
+                match message_type {
+                    Some("response") => handle_response(&pending_clone, message),
+                    Some("callback") => handle_callback(&callbacks_clone, message),
+                    _ => {}
+                }
+            }
+        });
+
+        Self {
+            writer,
+            pending,
+            callbacks,
+        }
+    }
+
+    pub fn call(&self, method: &str, args: Vec<Arg>) -> Result<Value, RpcError> {
+        let request_id = generate_uuid();
+        let (sender, receiver): (ResponseSender, ResponseReceiver) = std::sync::mpsc::channel();
+        self.pending
+            .lock()
+            .expect("pending lock")
+            .insert(request_id.clone(), sender);
+
+        let mut processed_args: Vec<Value> = Vec::new();
+        let mut callback_ids: Vec<Value> = Vec::new();
+
+        for arg in args {
+            match arg {
+                Arg::Value(value) => processed_args.push(value),
+                Arg::Callback(callback) => {
+                    let callback_id = generate_uuid();
+                    self.callbacks
+                        .lock()
+                        .expect("callbacks lock")
+                        .insert(callback_id.clone(), callback);
+                    callback_ids.push(Value::String(callback_id.clone()));
+                    processed_args
+                        .push(Value::String(format!("{}{}", CALLBACK_PREFIX, callback_id)));
+                }
+            }
+        }
+
+        let mut payload = serde_json::Map::new();
+        payload.insert("id".to_string(), Value::String(request_id.clone()));
+        payload.insert("method".to_string(), Value::String(method.to_string()));
+        payload.insert("args".to_string(), Value::Array(processed_args));
+        payload.insert("type".to_string(), Value::String("request".to_string()));
+        payload.insert("version".to_string(), Value::String("json".to_string()));
+        if !callback_ids.is_empty() {
+            payload.insert("callbackIds".to_string(), Value::Array(callback_ids));
+        }
+
+        write_message(&self.writer, Value::Object(payload));
+
+        let response = receiver.recv().expect("response received");
+        if let Some(error) = response.error {
+            return Err(error);
+        }
+        Ok(response.result.unwrap_or(Value::Null))
+    }
+}
+
+fn handle_response(pending: &Arc<Mutex<HashMap<String, ResponseSender>>>, message: Value) {
+    let request_id = message.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let sender = pending.lock().expect("pending lock").remove(request_id);
+    let sender = match sender {
+        Some(sender) => sender,
+        None => return,
+    };
+
+    let args = message.get("args").cloned().unwrap_or(Value::Null);
+    if let Some(error_value) = args.get("error") {
+        let error = if let Some(error_obj) = error_value.as_object() {
+            let name = error_obj
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(|v| v.to_string());
+            let message = error_obj
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("RPC error")
+                .to_string();
+            RpcError {
+                name,
+                message,
+                data: error_value.clone(),
+            }
+        } else {
+            RpcError {
+                name: None,
+                message: error_value.to_string(),
+                data: error_value.clone(),
+            }
+        };
+        let _ = sender.send(ResponsePayload {
+            result: None,
+            error: Some(error),
+        });
+        return;
+    }
+
+    let result = args.get("result").cloned();
+    let _ = sender.send(ResponsePayload {
+        result,
+        error: None,
+    });
+}
+
+fn handle_callback(callbacks: &Arc<Mutex<HashMap<String, Callback>>>, message: Value) {
+    let callback_id = message.get("method").and_then(|v| v.as_str());
+    let callback_id = match callback_id {
+        Some(id) => id,
+        None => return,
+    };
+    let callback = callbacks
+        .lock()
+        .expect("callbacks lock")
+        .get(callback_id)
+        .cloned();
+    let callback = match callback {
+        Some(callback) => callback,
+        None => return,
+    };
+    let args = message
+        .get("args")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    callback(args);
+}
+
+fn write_message<W: Write>(writer: &Arc<Mutex<W>>, message: Value) {
+    let serialized = match serde_json::to_string(&message) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+    if let Ok(mut guard) = writer.lock() {
+        let _ = writeln!(guard, "{}", serialized);
+        let _ = guard.flush();
+    }
+}
+
+pub fn generate_uuid() -> String {
+    let mut rng = rand::thread_rng();
+    let parts: Vec<String> = (0..4).map(|_| format!("{:x}", rng.gen::<u64>())).collect();
+    parts.join("-")
+}

--- a/interop/rust/src/main.rs
+++ b/interop/rust/src/main.rs
@@ -1,0 +1,92 @@
+use serde_json::{json, Value};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+use kkrpc_interop::{Arg, Client};
+
+fn main() {
+    let root = std::env::current_dir().expect("cwd");
+    let server_path = root.join("interop").join("node").join("server.ts");
+
+    let mut child = Command::new("bun")
+        .arg(server_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn bun server");
+
+    let stdout = child.stdout.take().expect("stdout");
+    let stdin = child.stdin.take().expect("stdin");
+
+    let client = Client::new(stdout, stdin);
+
+    let result = client
+        .call("math.add", vec![Arg::Value(json!(3)), Arg::Value(json!(6))])
+        .expect("call math.add");
+    assert_eq!(result.as_i64(), Some(9));
+
+    let echo_input = json!({"name": "kkrpc", "count": 3});
+    let echo_result = client
+        .call("echo", vec![Arg::Value(echo_input.clone())])
+        .expect("call echo");
+    assert!(compare_maps(&echo_input, &echo_result));
+
+    let (callback_sender, callback_receiver) = mpsc::channel::<String>();
+    let callback = move |args: Vec<Value>| {
+        if let Some(first) = args.get(0) {
+            let _ = callback_sender.send(first.to_string().trim_matches('"').to_string());
+        }
+    };
+
+    let callback_result = client
+        .call(
+            "withCallback",
+            vec![
+                Arg::Value(json!("pong")),
+                Arg::Callback(std::sync::Arc::new(callback)),
+            ],
+        )
+        .expect("call withCallback");
+    assert_eq!(callback_result.as_str(), Some("callback-sent"));
+
+    let callback_value = callback_receiver
+        .recv_timeout(Duration::from_secs(2))
+        .expect("callback received");
+    assert_eq!(callback_value, "callback:pong");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn compare_maps(expected: &Value, actual: &Value) -> bool {
+    let expected_map = match expected.as_object() {
+        Some(map) => map,
+        None => return false,
+    };
+    let actual_map = match actual.as_object() {
+        Some(map) => map,
+        None => return false,
+    };
+
+    for (key, expected_value) in expected_map.iter() {
+        let Some(actual_value) = actual_map.get(key) else {
+            return false;
+        };
+        if !values_equal(expected_value, actual_value) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn values_equal(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::Number(expected_number), Value::Number(actual_number)) => {
+            expected_number.as_f64() == actual_number.as_f64()
+        }
+        _ => expected == actual,
+    }
+}

--- a/interop/rust/src/main.rs
+++ b/interop/rust/src/main.rs
@@ -26,12 +26,14 @@ fn main() {
         .call("math.add", vec![Arg::Value(json!(3)), Arg::Value(json!(6))])
         .expect("call math.add");
     assert_eq!(result.as_i64(), Some(9));
+    println!("[rust] math.add(3, 6) => {}", result);
 
     let echo_input = json!({"name": "kkrpc", "count": 3});
     let echo_result = client
         .call("echo", vec![Arg::Value(echo_input.clone())])
         .expect("call echo");
     assert!(compare_maps(&echo_input, &echo_result));
+    println!("[rust] echo({}) => {}", echo_input, echo_result);
 
     let (callback_sender, callback_receiver) = mpsc::channel::<String>();
     let callback = move |args: Vec<Value>| {
@@ -50,11 +52,13 @@ fn main() {
         )
         .expect("call withCallback");
     assert_eq!(callback_result.as_str(), Some("callback-sent"));
+    println!("[rust] withCallback(\"pong\", cb) => {}", callback_result);
 
     let callback_value = callback_receiver
         .recv_timeout(Duration::from_secs(2))
         .expect("callback received");
     assert_eq!(callback_value, "callback:pong");
+    println!("[rust] callback received => {}", callback_value);
 
     let _ = child.kill();
     let _ = child.wait();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "kkrpc"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = []


### PR DESCRIPTION
### Motivation
- Provide a Rust reference implementation so non-JS runtimes can interoperate with kkrpc using the newline-delimited JSON fallback (`version: "json"`).
- Match the existing Python and Go interop examples by supporting requests, responses, and callback invocation over stdio for smoke-testing the TypeScript JSON-mode server.

### Description
- Add a new Cargo project at `interop/rust/` containing a JSON-mode client library (`src/lib.rs`) that implements request/response handling, callback mapping (`"__callback__<id>"`), a reader loop, and a `generate_uuid()` helper.
- Add a smoke runner `interop/rust/src/main.rs` that spawns the Node/Bun JSON-mode server (`interop/node/server.ts`) and exercises `math.add`, `echo`, and `withCallback` assertions.
- Add `interop/rust/Cargo.toml` with dependencies and update `interop/README.md` to document the new Rust interop example.
- The Rust client API mirrors the other language examples and serializes messages with `type`, `id`, `method`, `args`, `version: "json"`, and optional `callbackIds`.

### Testing
- Ran `cargo fmt --manifest-path interop/rust/Cargo.toml` successfully to format the new Rust sources.
- Attempted `cargo run --manifest-path interop/rust/Cargo.toml`, which failed due to crates.io access being blocked in this environment (`download config.json failed`, HTTP 403), so runtime smoke execution could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69836f8c7aec832fa0cdc42c6436988b)